### PR TITLE
Randomize player selection for AI reviews

### DIFF
--- a/packages/backend/src/league/review/generator.ts
+++ b/packages/backend/src/league/review/generator.ts
@@ -189,8 +189,14 @@ async function generateAIReview(
 
     console.log(`[generateAIReview] Selected personality: ${personality.filename}`);
 
+    // Select a random player from the match (for multi-player tracked games)
+    const playerIndex = Math.floor(Math.random() * match.players.length);
+    const player = match.players[playerIndex];
+    console.log(
+      `[generateAIReview] Selected player ${(playerIndex + 1).toString()}/${match.players.length.toString()}: ${player?.playerConfig.alias ?? "unknown"}`,
+    );
+
     // Get lane context
-    const player = match.players[0];
     const lane = match.queueType === "arena" ? undefined : player && "lane" in player ? player.lane : undefined;
     const laneContextInfo = await getLaneContext(lane);
     console.log(`[generateAIReview] Selected lane context: ${laneContextInfo.filename}`);
@@ -216,6 +222,7 @@ async function generateAIReview(
       model: "gpt-5",
       maxTokens: 25000,
       curatedData,
+      playerIndex,
     });
 
     console.log("[generateAIReview] Successfully generated AI review");

--- a/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
+++ b/packages/backend/src/league/tasks/postmatch/match-report-generator.ts
@@ -311,9 +311,9 @@ async function processStandardMatch(
   const queueType = completedMatch.queueType ?? "custom";
   const completionMessage = formatGameCompletionMessage(playerAliases, queueType);
 
-  // Combine completion message with review text if available
+  // Combine completion message with review text if available (always include text, even with image)
   let messageContent = completionMessage;
-  if (reviewText && !reviewImage) {
+  if (reviewText) {
     messageContent = `${completionMessage}\n\n${reviewText}`;
   }
 

--- a/packages/data/src/review/generator-helpers.ts
+++ b/packages/data/src/review/generator-helpers.ts
@@ -11,14 +11,19 @@ import type {
 /**
  * Extract match data from a match object
  * Handles both arena and regular matches
+ * @param match - The completed match data
+ * @param playerIndex - Optional index of the player to extract data for (defaults to 0)
  */
-export function extractMatchData(match: CompletedMatch | ArenaMatch): {
+export function extractMatchData(
+  match: CompletedMatch | ArenaMatch,
+  playerIndex = 0,
+): {
   matchData: Record<string, string>;
   lane: string | undefined;
 } {
   return matchPattern(match)
     .with({ queueType: "arena" }, (arenaMatch: ArenaMatch) => {
-      const player = arenaMatch.players[0];
+      const player = arenaMatch.players[playerIndex] ?? arenaMatch.players[0];
       if (!player) {
         throw new Error("No player data found");
       }
@@ -42,7 +47,7 @@ export function extractMatchData(match: CompletedMatch | ArenaMatch): {
       };
     })
     .otherwise((regularMatch: CompletedMatch) => {
-      const player = regularMatch.players[0];
+      const player = regularMatch.players[playerIndex] ?? regularMatch.players[0];
       if (!player) {
         throw new Error("No player data found");
       }

--- a/packages/data/src/review/generator.ts
+++ b/packages/data/src/review/generator.ts
@@ -55,6 +55,7 @@ export async function generateReviewText(params: {
   topP?: number | undefined;
   curatedData?: CuratedMatchData | undefined;
   systemPromptPrefix?: string | undefined;
+  playerIndex?: number | undefined;
 }): Promise<{ text: string; metadata: ReviewTextMetadata }> {
   const {
     match,
@@ -69,9 +70,10 @@ export async function generateReviewText(params: {
     topP,
     curatedData,
     systemPromptPrefix = "",
+    playerIndex = 0,
   } = params;
 
-  const { matchData } = extractMatchData(match);
+  const { matchData } = extractMatchData(match, playerIndex);
   const promptVariables = buildPromptVariables({
     matchData,
     personality,


### PR DESCRIPTION
- Select random tracked player instead of always using first player for AI reviews
- Pass player index through generateReviewText to extractMatchData
- Always include AI text review in Discord messages, even when image is present