### PR TITLE
Fix Cloudflare Insights beacon blocked error

### DIFF
--- a/packages/report/src/dataDragon/version.ts
+++ b/packages/report/src/dataDragon/version.ts
@@ -1,24 +1,30 @@
 import { z } from "zod";
 import { first } from "remeda";
 
-// Allow pinning the version via environment variable for deterministic tests
-const pinnedVersion = Bun.env["DATA_DRAGON_VERSION"];
-
 let resolvedVersion: string;
 
-if (pinnedVersion) {
-  resolvedVersion = pinnedVersion;
+if (typeof Bun === "undefined") {
+  // Browser fallback: use a known stable version
+  // ddragon is backwards compatible so this will work even if slightly outdated
+  resolvedVersion = "14.24.1";
 } else {
-  const versions = z
-    .array(z.string())
-    .parse(await (await fetch("https://ddragon.leagueoflegends.com/api/versions.json")).json());
+  // Server-side: Allow pinning the version via environment variable for deterministic tests
+  const pinnedVersion = Bun.env["DATA_DRAGON_VERSION"];
 
-  const firstVersion = first(versions);
+  if (pinnedVersion) {
+    resolvedVersion = pinnedVersion;
+  } else {
+    const versions = z
+      .array(z.string())
+      .parse(await (await fetch("https://ddragon.leagueoflegends.com/api/versions.json")).json());
 
-  if (firstVersion === undefined) {
-    throw new Error("latest version is undefined");
+    const firstVersion = first(versions);
+
+    if (firstVersion === undefined) {
+      throw new Error("latest version is undefined");
+    }
+    resolvedVersion = firstVersion;
   }
-  resolvedVersion = firstVersion;
 }
 
 export const latestVersion = resolvedVersion;


### PR DESCRIPTION
The version.ts file was accessing Bun.env at module level without checking if Bun was available. This caused "Bun is not defined" errors when the code was bundled for browser environments.

Now checks typeof Bun first and provides a fallback version for browsers. The ddragon API is backwards compatible so using a hardcoded version is safe.