### PR TITLE
Fix React error 482 in review tool

### DIFF
--- a/packages/frontend/src/components/review-tool/cost-display.tsx
+++ b/packages/frontend/src/components/review-tool/cost-display.tsx
@@ -1,7 +1,7 @@
 /**
  * Cost tracking display component
  */
-import { useSyncExternalStore, useRef } from "react";
+import { useSyncExternalStore, useRef, useCallback } from "react";
 import type { CostTracker } from "@scout-for-lol/frontend/lib/review-tool/costs";
 import type { CostBreakdown } from "@scout-for-lol/frontend/lib/review-tool/config/schema";
 import { formatCost } from "@scout-for-lol/frontend/lib/review-tool/costs";
@@ -67,9 +67,15 @@ export function CostDisplay({ costTracker }: CostDisplayProps) {
     })();
   }
 
+  // Memoize subscribe function to ensure stable reference for useSyncExternalStore
+  const subscribeToCostTotalCallback = useCallback(
+    (callback: () => void) => subscribeToCostTotal(callback, costTrackerRef.current),
+    [], // costTrackerRef is a ref, stable across renders
+  );
+
   // Subscribe to cost total updates
   const total = useSyncExternalStore(
-    (callback) => subscribeToCostTotal(callback, costTrackerRef.current),
+    subscribeToCostTotalCallback,
     getCostTotalSnapshot,
     getCostTotalSnapshot,
   );

--- a/packages/frontend/src/components/review-tool/results-panel.tsx
+++ b/packages/frontend/src/components/review-tool/results-panel.tsx
@@ -29,6 +29,18 @@ import { ResultRating } from "./result-rating";
 
 const ErrorSchema = z.object({ message: z.string() });
 
+// External store for cost update events - must be outside component for stable references
+function subscribeToCostUpdates(callback: () => void) {
+  window.addEventListener("cost-update", callback);
+  return () => {
+    window.removeEventListener("cost-update", callback);
+  };
+}
+
+function getCostUpdateSnapshot() {
+  return Date.now();
+}
+
 type ResultsPanelProps = {
   config: ReviewConfig;
   match?: CompletedMatch | ArenaMatch | undefined;
@@ -50,18 +62,8 @@ export function ResultsPanel({ config, match, result, costTracker, onResultGener
   const [viewingHistory, setViewingHistory] = useState(false);
   const [rating, setRating] = useState<1 | 2 | 3 | 4 | undefined>();
   const [notes, setNotes] = useState("");
-  // Subscribe to cost update events using useSyncExternalStore
-  function subscribeToCostUpdates(callback: () => void) {
-    window.addEventListener("cost-update", callback);
-    return () => {
-      window.removeEventListener("cost-update", callback);
-    };
-  }
 
-  function getCostUpdateSnapshot() {
-    return Date.now();
-  }
-
+  // Subscribe to cost update events
   useSyncExternalStore(subscribeToCostUpdates, getCostUpdateSnapshot, getCostUpdateSnapshot);
 
   // Calculate elapsed times during render - recalculates on every render


### PR DESCRIPTION
…error #482

- Move subscribeToCostUpdates and getCostUpdateSnapshot outside component in results-panel.tsx to ensure stable function references
- Use useCallback for subscribeToCostTotalCallback in cost-display.tsx to prevent recreating the subscribe function on every render

This fixes React error #482 which occurs when useSyncExternalStore receives unstable subscribe function references, causing React's reconciliation to fail.