### PR TITLE
Fix React error 482 in review tool

### DIFF
--- a/packages/frontend/src/components/review-tool/results-panel.tsx
+++ b/packages/frontend/src/components/review-tool/results-panel.tsx
@@ -30,15 +30,22 @@ import { ResultRating } from "./result-rating";
 const ErrorSchema = z.object({ message: z.string() });
 
 // External store for cost update events - must be outside component for stable references
+// Track the actual update count, NOT Date.now() which changes every call and breaks useSyncExternalStore
+let costUpdateCount = 0;
+
 function subscribeToCostUpdates(callback: () => void) {
-  window.addEventListener("cost-update", callback);
+  const handler = () => {
+    costUpdateCount += 1;
+    callback();
+  };
+  window.addEventListener("cost-update", handler);
   return () => {
-    window.removeEventListener("cost-update", callback);
+    window.removeEventListener("cost-update", handler);
   };
 }
 
 function getCostUpdateSnapshot() {
-  return Date.now();
+  return costUpdateCount;
 }
 
 type ResultsPanelProps = {


### PR DESCRIPTION
The getCostUpdateSnapshot function was returning Date.now() which changes on every call, violating useSyncExternalStore's contract that getSnapshot should return the same value when the external store hasn't changed.

This caused React error #482 because React detected the store value was constantly changing and triggered continuous re-subscriptions.

The fix tracks an actual update counter that only increments when a cost-update event fires, providing a stable reference for React.