### PR TITLE
Fix string length validation error

### DIFF
--- a/packages/data/src/model/discord.ts
+++ b/packages/data/src/model/discord.ts
@@ -4,7 +4,7 @@ export type DiscordGuildId = z.infer<typeof DiscordGuildIdSchema>;
 export const DiscordGuildIdSchema = z.string().min(17).max(20).regex(/^\d+$/).brand<"DiscordGuildId">();
 
 export type DiscordAccountId = z.infer<typeof DiscordAccountIdSchema>;
-export const DiscordAccountIdSchema = z.string().min(17).max(18).regex(/^\d+$/).brand<"DiscordAccountId">();
+export const DiscordAccountIdSchema = z.string().min(17).max(20).regex(/^\d+$/).brand<"DiscordAccountId">();
 
 export type DiscordChannelId = z.infer<typeof DiscordChannelIdSchema>;
 export const DiscordChannelIdSchema = z.string().min(17).max(20).regex(/^\d+$/).brand<"DiscordChannelId">();


### PR DESCRIPTION
Discord snowflake IDs can be up to 19-20 digits. The previous max of 18 was causing validation errors for newer Discord account IDs. This aligns the schema with DiscordGuildIdSchema and DiscordChannelIdSchema which already use max(20).