### PR TITLE
Add Rust checks to pre-commit hooks

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,10 @@
       "bash -c 'cd packages/desktop && bunx eslint --cache --fix'",
       "bun ./scripts/run-relevant-tests.ts packages/desktop"
     ],
+    "packages/desktop/src-tauri/**/*.rs": [
+      "bash -c 'cd packages/desktop/src-tauri && cargo fmt --check'",
+      "bash -c 'cd packages/desktop/src-tauri && cargo clippy -- -D warnings'"
+    ],
     "*.{ts,tsx,js,jsx}": "bun run scripts/check-suppressions.ts"
   },
   "dependencies": {


### PR DESCRIPTION
Add lint-staged configuration for Rust files in the desktop/src-tauri directory. Runs cargo fmt --check and cargo clippy on staged .rs files.