### PR TITLE
Investigate GitHub issue 193 with web fetch

### DIFF
--- a/packages/backend/src/discord/commands/admin/index.ts
+++ b/packages/backend/src/discord/commands/admin/index.ts
@@ -68,24 +68,7 @@ export const adminCommand = new SlashCommandBuilder()
           .setName("region")
           .setDescription("The region of the account")
           .setRequired(true)
-          .addChoices(
-            { name: "NA (North America)", value: "na1" },
-            { name: "EUW (Europe West)", value: "euw1" },
-            { name: "EUNE (Europe Nordic & East)", value: "eun1" },
-            { name: "KR (Korea)", value: "kr" },
-            { name: "BR (Brazil)", value: "br1" },
-            { name: "LAN (Latin America North)", value: "la1" },
-            { name: "LAS (Latin America South)", value: "la2" },
-            { name: "OCE (Oceania)", value: "oc1" },
-            { name: "RU (Russia)", value: "ru" },
-            { name: "TR (Turkey)", value: "tr1" },
-            { name: "JP (Japan)", value: "jp1" },
-            { name: "PH (Philippines)", value: "ph2" },
-            { name: "SG (Singapore)", value: "sg2" },
-            { name: "TH (Thailand)", value: "th2" },
-            { name: "TW (Taiwan)", value: "tw2" },
-            { name: "VN (Vietnam)", value: "vn2" },
-          ),
+          .addChoices(...REGION_CHOICES),
       )
       .addStringOption((option) =>
         option

--- a/packages/backend/src/discord/commands/admin/utils/region-choices.ts
+++ b/packages/backend/src/discord/commands/admin/utils/region-choices.ts
@@ -1,22 +1,11 @@
+import { RegionSchema, toReadableRegion } from "@scout-for-lol/data";
+
 /**
  * Region choices for Discord command options
  * Used across multiple admin commands that require region selection
+ * Values match RegionSchema enum values for proper validation
  */
-export const REGION_CHOICES = [
-  { name: "NA (North America)", value: "na1" },
-  { name: "EUW (Europe West)", value: "euw1" },
-  { name: "EUNE (Europe Nordic & East)", value: "eun1" },
-  { name: "KR (Korea)", value: "kr" },
-  { name: "BR (Brazil)", value: "br1" },
-  { name: "LAN (Latin America North)", value: "la1" },
-  { name: "LAS (Latin America South)", value: "la2" },
-  { name: "OCE (Oceania)", value: "oc1" },
-  { name: "RU (Russia)", value: "ru" },
-  { name: "TR (Turkey)", value: "tr1" },
-  { name: "JP (Japan)", value: "jp1" },
-  { name: "PH (Philippines)", value: "ph2" },
-  { name: "SG (Singapore)", value: "sg2" },
-  { name: "TH (Thailand)", value: "th2" },
-  { name: "TW (Taiwan)", value: "tw2" },
-  { name: "VN (Vietnam)", value: "vn2" },
-] as const;
+export const REGION_CHOICES = RegionSchema.options.map((region) => ({
+  name: toReadableRegion(region),
+  value: region,
+}));


### PR DESCRIPTION
The admin commands (account-add, account-delete, account-transfer) were using Riot platform IDs (na1, euw1, etc.) as Discord choice values, but the validation schema (RegionSchema) expects internal enum values (AMERICA_NORTH, EU_WEST, etc.). This caused Zod validation errors.

Fix by generating region choices from RegionSchema.options, matching the pattern already used by the subscription command.

Fixes #193